### PR TITLE
Fix issue with emptying cart and handling errors in PicPay gateway

### DIFF
--- a/includes/class-wc-picpay-gateway.php
+++ b/includes/class-wc-picpay-gateway.php
@@ -225,7 +225,10 @@ class WC_PicPay_Gateway extends WC_Payment_Gateway {
 			}
 
 			// Remove cart.
-			WC()->cart->empty_cart();
+			if(method_exists(WC()->cart, 'empty_cart'))
+			{
+				WC()->cart->empty_cart();
+			}
 			
 			$order->add_order_note(__('PicPay: The buyer initiated the transaction, but so far the PicPay not received any payment information.', 'woo-picpay'));
 			
@@ -241,7 +244,11 @@ class WC_PicPay_Gateway extends WC_Payment_Gateway {
 		}
 		else {
 			foreach($response['error'] as $error) {
-				wc_add_notice($error, 'error');
+				if($is_rest_api) {
+					error_log('PicPay Error: ' . $error);
+				} else {
+					wc_add_notice($error, 'error');
+				}
 			}
         
 			return array(


### PR DESCRIPTION
When calling from REST API some methods are not available also maybe the cart isn't present since we may are charging a order created from rest (where WC()->cart) is empty.

Also wc_add_notice isn't available when doing rest api calls.